### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/3rd Party/modules/convolution.py
+++ b/3rd Party/modules/convolution.py
@@ -24,6 +24,11 @@ from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import sparse_ops
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 class Convolution(Module):
     '''


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of a revamped version of __range()__ so this PR provides equivalent functionality in both Python 2 and Python 3.